### PR TITLE
fix(requirements.txt): Use git nextcord, for the display_name fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nextcord[speed, voice]  == 2.6.*
+nextcord[speed, voice]  @ git+https://github.com/ToasterUwU/nextcord.git@display_name-behaviour-correction
 orjson                  == 3.9.*
 aiohttp                 == 3.8.*
 Levenshtein             == 0.23.*


### PR DESCRIPTION
Updated the nextcord dependency in requirements.txt. The version has
been switched from a generic version to a version from a specific GitHub
repository that corrects display name behaviour. No other dependencies
were affected.